### PR TITLE
Linux: Support for System Wide installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ option(CENDRIC_STEAM "Include steamworks API?" OFF)
 option(CENDRIC_EXTERNAL_DOCUMENT_FOLDER "Use external documents folder?" OFF)
 option(CENDRIC_GERMAN "Use German as default language?" OFF)
 option(USE_SYSTEM_SFML "Use system SFML lib instead of internal" OFF)
+option(USE_SYSTEM_PATHS "Use system paths for loading ressources instead of local one" OFF)
 
 if (NOT IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/ext/sfml/src AND NOT USE_SYSTEM_SFML)
     message(FATAL_ERROR
@@ -39,6 +40,10 @@ else ()
 			)
 	endif()
 endif()
+
+if (USE_SYSTEM_PATHS)
+	add_definitions ("-DUSE_SYSTEM_PATHS")
+endif()		
 
 if (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,9 @@ option(CENDRIC_BUILD_DIALOGUE_TOOL "Build Dialogue Tool on Windows platform?" ON
 option(CENDRIC_STEAM "Include steamworks API?" OFF)
 option(CENDRIC_EXTERNAL_DOCUMENT_FOLDER "Use external documents folder?" OFF)
 option(CENDRIC_GERMAN "Use German as default language?" OFF)
+option(USE_SYSTEM_SFML "Use system SFML lib instead of internal" OFF)
 
-if (NOT IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/ext/sfml/src)
+if (NOT IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/ext/sfml/src AND NOT USE_SYSTEM_SFML)
     message(FATAL_ERROR
         "Seems like some of the required dependencies are missing. "
         "This can happen if you did not clone the project with the --recursive flag. "
@@ -28,7 +29,16 @@ if (APPLE)
 	option(SFML_BUILD_FRAMEWORKS "" ON)
 endif()
 
-add_subdirectory("${PROJECT_SOURCE_DIR}/ext/sfml")
+if (NOT USE_SYSTEM_SFML)
+	add_subdirectory("${PROJECT_SOURCE_DIR}/ext/sfml")
+else ()
+	find_package(SFML 2.5 COMPONENTS system window graphics audio)
+	if(NOT SFML_FOUND)
+		message(FATAL_ERROR
+			"System SFML package not found, you should set USE_SYSTEM_SFML to off"
+			)
+	endif()
+endif()
 
 if (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ option(CENDRIC_STEAM "Include steamworks API?" OFF)
 option(CENDRIC_EXTERNAL_DOCUMENT_FOLDER "Use external documents folder?" OFF)
 option(CENDRIC_GERMAN "Use German as default language?" OFF)
 option(USE_SYSTEM_SFML "Use system SFML lib instead of internal" OFF)
-option(USE_SYSTEM_PATHS "Use system paths for loading ressources instead of local one" OFF)
+option(USE_SYSTEM_PATHS "Use system paths for loading ressources instead of local ones" OFF)
 
 if (NOT IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/ext/sfml/src AND NOT USE_SYSTEM_SFML)
     message(FATAL_ERROR
@@ -192,3 +192,16 @@ if (WIN32 AND CENDRIC_BUILD_DIALOGUE_TOOL)
 	)
 
 endif()
+
+set(RESDIR "share/Cendric" CACHE STRING "Directory Game Ressources are installed to")
+set(BINDIR "bin" CACHE STRING "Directory Game Binary is installed to")
+
+if (IS_ABSOLUTE "${RESDIR}")
+	add_definitions(-DRESDIR="${RESDIR}/")
+else()
+	add_definitions(-DRESDIR="${CMAKE_INSTALL_PREFIX}/${RESDIR}/")
+endif()
+
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/res" DESTINATION ${RESDIR})
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/db" DESTINATION ${RESDIR})
+install(TARGETS Cendric RUNTIME DESTINATION ${BINDIR})

--- a/include/Platform/CendricLinux.h
+++ b/include/Platform/CendricLinux.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <string>
+
+std::string getSystemResourcePath();
+std::string getExternalDocumentsPath();

--- a/src/Platform/CendricLinux.cpp
+++ b/src/Platform/CendricLinux.cpp
@@ -1,0 +1,42 @@
+#include "Platform/CendricLinux.h"
+
+#ifdef __linux__
+
+#include <cstdlib>
+#include <sys/stat.h>
+#include <errno.h>
+#include <iostream>
+#include "Logger.h"
+
+std::string getExternalDocumentsPath() {
+	std::string resultPath = "";
+	std::string savePath = "";
+	if(const char* env_p = std::getenv("XDG_DATA_HOME"))
+		resultPath = std::string(env_p) + "/Cendric/";
+	else if(const char* env_p = std::getenv("HOME"))
+        	resultPath = std::string(env_p) + "/.local/share/Cendric/";
+	
+	savePath = resultPath + std::string("saves");
+	if(mkdir(resultPath.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == -1) {
+		int errorpc = errno;
+		if(errorpc != EEXIST) {
+			g_logger->logError("PlatformLinux", "Dir " + resultPath + " could not be created. Error: " + std::to_string(errorpc));
+		}
+	}
+	if(mkdir(savePath.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == -1) {
+		int errorpc = errno;
+		if(errorpc != EEXIST) {
+			g_logger->logError("PlatformLinux", "Dir " + savePath + " could not be created. Error: " + std::to_string(errorpc));
+		}
+	}
+
+	return resultPath;
+}
+
+std::string getSystemResourcePath() {
+	std::string resultPath = "/usr/share/Cendric/";
+	//maybe do some more stuff?
+	return resultPath;
+}
+
+#endif

--- a/src/Platform/CendricLinux.cpp
+++ b/src/Platform/CendricLinux.cpp
@@ -34,9 +34,7 @@ std::string getExternalDocumentsPath() {
 }
 
 std::string getSystemResourcePath() {
-	std::string resultPath = "/usr/share/Cendric/";
-	//maybe do some more stuff?
-	return resultPath;
+	return RESDIR;
 }
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,8 @@
 #include "Platform/CendricWin32.h"
 #elif __APPLE__
 #include "Platform/CendricApple.h"
+#elif __linux__
+#include "Platform/CendricLinux.h"
 #endif
 
 std::string g_resourcePath = "";
@@ -27,6 +29,7 @@ int main(int argc, char* argv[]) {
 		ShowWindow(hWnd, SW_HIDE);
 	#endif
 #endif
+	g_logger = new Logger();
 
 #ifdef EXTERNAL_DOCUMENTS_FOLDER
 	g_documentsPath = getExternalDocumentsPath();
@@ -40,8 +43,12 @@ int main(int argc, char* argv[]) {
 		#endif
 	#endif
 #endif
+#ifdef __linux__
+	#ifdef USE_SYSTEM_PATHS
+		g_resourcePath = getSystemResourcePath();
+	#endif
+#endif
 
-	g_logger = new Logger();
 	g_databaseManager = new DatabaseManager();
 	g_resourceManager = new ResourceManager();
 	g_textProvider = new TextProvider();


### PR DESCRIPTION
Currently Cendric only allows Saves, Config and data files to be in the same dir as the bin.
This PR allows to set some compile time flags `USE_SYSTEM_PATHS` and `CENDRIC_EXTERNAL_DOCUMENT_FOLDER` on Linux so that data can be saved under `/usr/share/Cendric` and Save files and Config are und `~/.local/share/Cendric` so that it can be packaged by Linux Package Managers.

I shouldl add some checks to `getSystemResourcePath()` if the Directory actually exists and also maybe allow overriding it in the config file?